### PR TITLE
add reverse from Rust's Reverse

### DIFF
--- a/include/yk/util/reverse.hpp
+++ b/include/yk/util/reverse.hpp
@@ -5,6 +5,7 @@
 
 namespace yk {
 
+// note: Don't use this in projection with `std::forward_as_tuple` as it creates dangling reference
 template <class T>
 struct [[nodiscard]] reverse {
   T val;

--- a/include/yk/util/reverse.hpp
+++ b/include/yk/util/reverse.hpp
@@ -1,0 +1,27 @@
+#ifndef YK_UTIL_REVERSE_HPP
+#define YK_UTIL_REVERSE_HPP
+
+#include <compare>
+
+namespace yk {
+
+template <class T>
+struct [[nodiscard]] reverse {
+  T val;
+
+  [[nodiscard]] constexpr auto operator<=>(const reverse& other) const noexcept(noexcept(other.val <=> val)) -> std::compare_three_way_result_t<T> {
+    return other.val <=> val;
+  }
+
+  [[nodiscard]] constexpr bool operator==(const reverse& other) const noexcept(noexcept(val == other.val)) { return val == other.val; }
+};
+
+template <class T>
+reverse(T&) -> reverse<const T&>;
+
+template <class T>
+reverse(T&&) -> reverse<T>;
+
+}  // namespace yk
+
+#endif  // YK_UTIL_REVERSE_HPP

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -96,6 +96,15 @@ BOOST_AUTO_TEST_CASE(Reverse) {
   static_assert(std::ranges::equal(
       []() {
         std::vector<S> vec{{3, 1, 4}, {1, 5, 9}, {2, 6, 5}, {3, 5, 8}, {9, 7, 9}, {3, 2, 3}, {8, 4, 6}};
+        std::ranges::sort(
+            vec, [](const S& x, const S& y) { return std::forward_as_tuple(x.a, yk::reverse(x.b), x.c) < std::forward_as_tuple(y.a, yk::reverse(y.b), y.c); });
+        return vec;
+      }(),
+      std::vector<S>{{1, 5, 9}, {2, 6, 5}, {3, 5, 8}, {3, 2, 3}, {3, 1, 4}, {8, 4, 6}, {9, 7, 9}}));
+
+  static_assert(std::ranges::equal(
+      []() {
+        std::vector<S> vec{{3, 1, 4}, {1, 5, 9}, {2, 6, 5}, {3, 5, 8}, {9, 7, 9}, {3, 2, 3}, {8, 4, 6}};
         std::ranges::sort(vec, {}, [](const S& s) { return std::make_tuple(std::cref(s.a), yk::reverse(s.b), std::cref(s.c)); });
         return vec;
       }(),

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -1,11 +1,13 @@
 #include "yk/util/forward_like.hpp"
 #include "yk/util/pack_indexing.hpp"
+#include "yk/util/reverse.hpp"
 #include "yk/util/specialization_of.hpp"
 #include "yk/util/to_array_of.hpp"
 
 #define BOOST_TEST_MODULE yk_util_test
 #include <boost/test/included/unit_test.hpp>
 
+#include <functional>
 #include <string>
 #include <utility>
 #include <vector>
@@ -80,6 +82,24 @@ BOOST_AUTO_TEST_CASE(ToArrayOf) {
 
   enum class StrongID : int {};
   constexpr auto predefined_ids = yk::to_array_of<StrongID>(1, 2, 3);
+}
+
+BOOST_AUTO_TEST_CASE(Reverse) {
+  static_assert(yk::reverse(42) < yk::reverse(33 - 4));
+  static_assert(yk::reverse(42) == yk::reverse(42));
+
+  struct S {
+    int a, b, c;
+    constexpr bool operator==(const S&) const noexcept = default;
+  };
+
+  static_assert(std::ranges::equal(
+      []() {
+        std::vector<S> vec{{3, 1, 4}, {1, 5, 9}, {2, 6, 5}, {3, 5, 8}, {9, 7, 9}, {3, 2, 3}, {8, 4, 6}};
+        std::ranges::sort(vec, {}, [](const S& s) { return std::make_tuple(std::cref(s.a), yk::reverse(s.b), std::cref(s.c)); });
+        return vec;
+      }(),
+      std::vector<S>{{1, 5, 9}, {2, 6, 5}, {3, 5, 8}, {3, 2, 3}, {3, 1, 4}, {8, 4, 6}, {9, 7, 9}}));
 }
 
 BOOST_AUTO_TEST_SUITE_END()  // yk_util


### PR DESCRIPTION
Since this is not projection+`forward_as_tuple`-friendly, I suppose this is not so useful (using this in comparison is OK but bit ugly)