### PR TITLE
Use shared_mutex for abort_policy

### DIFF
--- a/include/yk/par_for_each.hpp
+++ b/include/yk/par_for_each.hpp
@@ -8,7 +8,7 @@
 #include <algorithm>
 #include <exception>
 #include <execution>
-#include <mutex>
+#include <shared_mutex>
 #include <ranges>
 #include <type_traits>
 #include <utility>
@@ -42,12 +42,12 @@ void for_each(JobPolicy&&, Policy&& policy, ForwardIterator first, ForwardIterat
   static_assert(is_job_policy_v<std::remove_cvref_t<JobPolicy>>);
   static_assert(std::is_execution_policy_v<std::remove_cvref_t<Policy>>);
   static_assert(std::is_copy_constructible_v<Func>, "std::for_each requires func to be CopyConstructible");
-  std::mutex mtx;
+  std::shared_mutex mtx;
   std::exception_ptr exception;
   const auto wrapper = [&, func = std::move(func)]<class T>(T&& arg) noexcept {
     try {
       if constexpr (std::is_same_v<std::remove_cvref_t<JobPolicy>, execution::abort_policy>) {
-        std::lock_guard lock{mtx};
+        std::shared_lock lock{mtx};
         if (exception) return;
       }
       std::invoke(func, std::forward<T>(arg));

--- a/include/yk/par_for_each.hpp
+++ b/include/yk/par_for_each.hpp
@@ -8,8 +8,8 @@
 #include <algorithm>
 #include <exception>
 #include <execution>
-#include <shared_mutex>
 #include <ranges>
+#include <shared_mutex>
 #include <type_traits>
 #include <utility>
 


### PR DESCRIPTION
`std::shared_mutex` is way faster than `std::mutex` since we don't have exceptions for 99% of the times (benchmarked on real-world data)