### PR TITLE
Correctly promote `partial | promote(partial)`

### DIFF
--- a/include/yk/compare/comparator.hpp
+++ b/include/yk/compare/comparator.hpp
@@ -280,8 +280,14 @@ struct promote_comparator : comparator_interface {
     const auto res = std::invoke(comp1, x, y);
 
     if constexpr (std::same_as<From, To>) {
-      if (res == From::equivalent) return std::invoke(comp2, x, y);
-      return res;
+      if constexpr (std::same_as<From, std::partial_ordering>) {
+        if (res == From::equivalent || res == From::unordered) return std::invoke(comp2, x, y);
+        return res;
+
+      } else {
+        if (res == From::equivalent) return std::invoke(comp2, x, y);
+        return res;
+      }
 
     } else {
       if (res == From::less) return To::less;


### PR DESCRIPTION
```cpp
// previous implementation
BOOST_TEST(((PartialPartial{NaN, 1.0} <=> PartialPartial{NaN, 2.0}) == std::partial_ordering::unordered));
BOOST_TEST((comp(PartialPartial{NaN, 1.0}, PartialPartial{NaN, 2.0}) == std::partial_ordering::unordered));

// after this PR
BOOST_TEST(((PartialPartial{NaN, 1.0} <=> PartialPartial{NaN, 2.0}) == std::partial_ordering::unordered));
BOOST_TEST((comp(PartialPartial{NaN, 1.0}, PartialPartial{NaN, 2.0}) == std::partial_ordering::less));
```

@yaito3014 Can you confirm this is correct? If so please merge thanks!